### PR TITLE
Refactor monolithic RAG service into modular modules

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,0 +1,51 @@
+import os
+from typing import Optional
+
+import chromadb
+
+from embedding import NomicOnnxEmbedder
+
+# Environment configuration
+OLLAMA_URL = os.getenv("OLLAMA_URL", "http://127.0.0.1:11434")
+OLLAMA_KEEP_ALIVE = os.getenv("OLLAMA_KEEP_ALIVE", "45m")
+EMBED_MODEL_DIR = os.getenv("EMBED_MODEL_DIR", "/opt/adam/models/nomic-ai/nomic-embed-text")
+CHAT_MODEL = os.getenv("CHAT_MODEL", "llama3:8b")
+CHROMA_DIR = os.getenv("CHROMA_DIR", "/srv/rag/chroma")
+WATCH_DIR = os.getenv("WATCH_DIR", "/srv/rag/watched")
+UPLOAD_DIR = os.getenv("UPLOAD_DIR", "/srv/rag/uploads")
+COLLECTION = os.getenv("COLLECTION", "company_docs")
+CHUNK_SIZE = int(os.getenv("CHUNK_SIZE", "1000"))
+CHUNK_OVERLAP = int(os.getenv("CHUNK_OVERLAP", "150"))
+Q_MAX = int(os.getenv("INGEST_QUEUE_MAX", "8"))
+
+# Model aliasing
+ALIAS_MAP = {
+    "Adam Lite": "adam-lite:latest",
+    "adam-lite": "adam-lite:latest",
+    "llama3:8b": "llama3:8b",
+}
+DEFAULT_MODEL = CHAT_MODEL
+
+
+def resolve_model(name: Optional[str]) -> str:
+    """Return an Ollama model tag given a friendly name or raw tag."""
+    if not name:
+        return DEFAULT_MODEL
+    return ALIAS_MAP.get(name, name)
+
+
+# Initialize embedder and vector collection
+EMBEDDER = NomicOnnxEmbedder(EMBED_MODEL_DIR)
+client = chromadb.PersistentClient(path=CHROMA_DIR)
+collection = client.get_or_create_collection(COLLECTION)
+
+# Supported file extensions
+SUPPORTED = (
+    ".pdf", ".docx", ".txt",
+    ".md", ".csv", ".log", ".json", ".py", ".cs", ".java",
+    ".html", ".htm",
+    ".eml", ".msg",
+    ".xlsx", ".pptx",
+    ".png", ".jpg", ".jpeg", ".tiff", ".tif",
+    ".doc", ".rtf",
+)

--- a/db.py
+++ b/db.py
@@ -1,0 +1,131 @@
+from pathlib import Path as _Path
+from typing import Any, Dict, List, Optional, Tuple
+
+from config import (
+    EMBEDDER,
+    collection,
+)
+from doc_utils import chunk_text, read_text, sha1, sanitize_metadata
+
+
+def embed(texts: List[str]) -> List[List[float]]:
+    return EMBEDDER.encode(texts, normalize_embeddings=True)
+
+
+def upsert_document(path: _Path, source: str) -> int:
+    text = read_text(path)
+    if not text:
+        return 0
+    try:
+        collection.delete(where={"path": str(path)})
+    except Exception:
+        pass
+
+    chunks = chunk_text(text)
+    if not chunks:
+        return 0
+    embs = embed(chunks)
+
+    doc_sha = sha1(path)
+    ids = [f"{doc_sha}:{i}" for i in range(len(chunks))]
+    metas = [{"source": source, "path": str(path), "chunk": i} for i in range(len(chunks))]
+    collection.upsert(ids=ids, documents=chunks, metadatas=metas, embeddings=embs)
+    return len(chunks)
+
+
+def upsert_text(doc_id: str, text: str, base_meta: Dict[str, Any]) -> int:
+    text = (text or "").strip()
+    if not text:
+        return 0
+    try:
+        collection.delete(where={"doc_id": doc_id})
+    except Exception:
+        pass
+    chunks = chunk_text(text)
+    if not chunks:
+        return 0
+    embs = embed(chunks)
+    ids = [f"{doc_id}:{i}" for i in range(len(chunks))]
+    metas = []
+    for i in range(len(chunks)):
+        m = sanitize_metadata(dict(base_meta))
+        m["doc_id"] = doc_id
+        m["chunk"] = i
+        metas.append(m)
+    collection.upsert(ids=ids, documents=chunks, metadatas=metas, embeddings=embs)
+    return len(chunks)
+
+
+def search(query: str, k: int = 4) -> List[Dict[str, Any]]:
+    qemb = embed([query])[0]
+    res = collection.query(query_embeddings=[qemb], n_results=k,
+                           include=["documents", "metadatas", "distances"])
+    docs = (res.get("documents") or [[]])[0]
+    metas = (res.get("metadatas") or [[]])[0]
+    dists = (res.get("distances") or [[]])[0]
+    return [{"text": d, "meta": m, "score": float(1.0 / (1e-5 + dist))}
+            for d, m, dist in zip(docs, metas, dists)]
+
+
+def search_filtered(
+    query: str,
+    k: int = 4,
+    path: Optional[str] = None,
+    paths: Optional[List[str]] = None,
+    prefix: Optional[str] = None,
+    source: Optional[str] = None,
+    org: Optional[str] = None,
+    category: Optional[str] = None,
+    doc_code: Optional[str] = None,
+    owner: Optional[str] = None,
+) -> List[Dict[str, Any]]:
+    qemb = embed([query])[0]
+    include = ["documents", "metadatas", "distances"]
+
+    def to_hits(res):
+        docs = (res.get("documents") or [[]])[0]
+        metas = (res.get("metadatas") or [[]])[0]
+        dists = (res.get("distances") or [[]])[0]
+        return [{"text": d, "meta": m, "score": float(1.0 / (1e-5 + dist))}
+                for d, m, dist in zip(docs, metas, dists)]
+
+    results: List[Dict[str, Any]] = []
+
+    if path:
+        res = collection.query(query_embeddings=[qemb], n_results=max(k, 8),
+                               include=include, where={"path": path})
+        results.extend(to_hits(res))
+    elif paths:
+        for p in paths:
+            res = collection.query(query_embeddings=[qemb], n_results=max(2, k // max(1, len(paths))) + 6,
+                                   include=include, where={"path": p})
+            results.extend(to_hits(res))
+    elif prefix:
+        try:
+            res = collection.query(query_embeddings=[qemb], n_results=max(k, 12),
+                                   include=include, where={"path": {"$contains": prefix}})
+            results.extend(to_hits(res))
+        except Exception:
+            res = collection.query(query_embeddings=[qemb], n_results=max(k * 5, 20), include=include)
+            results.extend([h for h in to_hits(res) if str(h["meta"].get("path", "")).startswith(prefix)])
+    elif source or org or category or doc_code or owner:
+        where: Dict[str, Any] = {}
+        if source:   where["source"] = source
+        if org:      where["org"] = org
+        if category: where["category"] = category
+        if doc_code: where["doc_code"] = doc_code
+        if owner:    where["owner"] = owner
+        res = collection.query(query_embeddings=[qemb], n_results=max(k, 12),
+                               include=include, where=where)
+        results.extend(to_hits(res))
+    else:
+        res = collection.query(query_embeddings=[qemb], n_results=k, include=include)
+        results.extend(to_hits(res))
+
+    seen: Dict[Tuple[Any, Any], Dict[str, Any]] = {}
+    for h in results:
+        key = (h["meta"].get("doc_id") or h["meta"].get("path"), h["meta"].get("chunk"))
+        if key not in seen or h["score"] > seen[key]["score"]:
+            seen[key] = h
+    hits = sorted(seen.values(), key=lambda x: x["score"], reverse=True)[:k]
+    return hits

--- a/doc_utils.py
+++ b/doc_utils.py
@@ -1,0 +1,185 @@
+import hashlib
+import subprocess
+from pathlib import Path as _Path
+from typing import Any, Dict, List
+import json
+
+from bs4 import BeautifulSoup
+from docx import Document
+from langchain_text_splitters import RecursiveCharacterTextSplitter
+from PIL import Image
+from pypdf import PdfReader
+from pdf2image import convert_from_path
+import pytesseract
+import openpyxl
+import extract_msg
+
+
+
+def sha1(path: _Path) -> str:
+    h = hashlib.sha1()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(8192), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def read_text(path: _Path) -> str:
+    ext = path.suffix.lower()
+
+    if ext == ".pdf":
+        # pypdf
+        try:
+            reader = PdfReader(str(path))
+            text = "\n".join(p.extract_text() or "" for p in reader.pages)
+            if text and len(text.strip()) > 50:
+                return text
+        except Exception:
+            pass
+        # pdftotext
+        try:
+            import subprocess
+            out = subprocess.run(["pdftotext", str(path), "-"] , capture_output=True, text=True, timeout=60)
+            return out.stdout
+        except Exception:
+            pass
+        # pdf2image + OCR
+        try:
+            images = convert_from_path(str(path))
+            return "\n".join(pytesseract.image_to_string(img) for img in images)
+        except Exception:
+            return ""
+
+    elif ext == ".docx":
+        try:
+            doc = Document(str(path))
+            return "\n".join(p.text for p in doc.paragraphs)
+        except Exception:
+            return ""
+
+    elif ext in (".txt", ".md", ".csv", ".log", ".json", ".py", ".cs", ".java"):
+        try:
+            return path.read_text(encoding="utf-8", errors="ignore")
+        except Exception:
+            return ""
+
+    elif ext in (".html", ".htm"):
+        try:
+            html = path.read_text(encoding="utf-8", errors="ignore")
+            soup = BeautifulSoup(html, "lxml")
+            return soup.get_text(separator="\n")
+        except Exception:
+            return ""
+
+    elif ext == ".eml":
+        try:
+            import email
+            msg = email.message_from_bytes(path.read_bytes())
+            parts = []
+            for part in msg.walk():
+                if part.get_content_type() == "text/plain":
+                    parts.append(part.get_payload(decode=True).decode(errors="ignore"))
+            return "\n".join(parts)
+        except Exception:
+            return ""
+
+    elif ext == ".msg":
+        try:
+            m = extract_msg.Message(str(path))
+            text = [m.subject or "", m.body or ""]
+            return "\n".join([t for t in text if t])
+        except Exception:
+            return ""
+
+    elif ext == ".xlsx":
+        try:
+            wb = openpyxl.load_workbook(str(path), data_only=True)
+            parts = []
+            for ws in wb.worksheets:
+                for row in ws.iter_rows(values_only=True):
+                    parts.append(" ".join([str(c) for c in row if c is not None]))
+            return "\n".join(parts)
+        except Exception:
+            return ""
+
+    elif ext == ".pptx":
+        try:
+            from pptx import Presentation
+            prs = Presentation(str(path))
+            parts = []
+            for slide in prs.slides:
+                for shp in slide.shapes:
+                    if hasattr(shp, "text") and shp.text:
+                        parts.append(shp.text)
+            return "\n".join(parts)
+        except Exception:
+            return ""
+
+    elif ext in (".png", ".jpg", ".jpeg", ".tiff", ".tif"):
+        try:
+            img = Image.open(str(path))
+            return pytesseract.image_to_string(img)
+        except Exception:
+            return ""
+
+    elif ext == ".doc":
+        # try antiword
+        try:
+            out = subprocess.run(["antiword", str(path)], capture_output=True, text=True, timeout=60)
+            if out.stdout.strip():
+                return out.stdout
+        except Exception:
+            pass
+        # fallback: convert to pdf via libreoffice headless
+        try:
+            subprocess.run(["libreoffice", "--headless", "--convert-to", "pdf",
+                            "--outdir", str(path.parent), str(path)], check=True, timeout=120)
+            pdf_path = path.with_suffix(".pdf")
+            if pdf_path.exists():
+                return read_text(pdf_path)
+        except Exception:
+            pass
+        return ""
+
+    elif ext == ".rtf":
+        try:
+            out = subprocess.run(["unrtf", "--text", str(path)], capture_output=True, text=True, timeout=60)
+            return out.stdout
+        except Exception:
+            return ""
+
+    else:
+        try:
+            return path.read_text(encoding="utf-8", errors="ignore")
+        except Exception:
+            return ""
+
+
+def chunk_text(text: str, size: int = None, overlap: int = None) -> List[str]:
+    from config import CHUNK_SIZE, CHUNK_OVERLAP
+    size = size or CHUNK_SIZE
+    overlap = overlap or CHUNK_OVERLAP
+    text = text.strip()
+    if not text:
+        return []
+    splitter = RecursiveCharacterTextSplitter(
+        chunk_size=size,
+        chunk_overlap=overlap,
+        separators=["\n\n", "\n", ". ", " ", ""],
+    )
+    return splitter.split_text(text)
+
+
+def sanitize_metadata(meta: Dict[str, Any]) -> Dict[str, Any]:
+    safe: Dict[str, Any] = {}
+    for k, v in (meta or {}).items():
+        if isinstance(v, (str, int, float, bool)) or v is None:
+            safe[k] = v
+        elif isinstance(v, (list, dict, tuple, set)):
+            try:
+                safe[k] = json.dumps(v, ensure_ascii=False)
+            except Exception:
+                safe[k] = str(v)
+        else:
+            safe[k] = str(v)
+    return safe

--- a/embedding.py
+++ b/embedding.py
@@ -1,0 +1,99 @@
+import os
+from typing import List
+
+import numpy as np
+import onnxruntime as ort
+from tokenizers import Tokenizer
+
+
+class NomicOnnxEmbedder:
+    """ONNXRuntime wrapper for nomic-ai/nomic-embed-text local model."""
+
+    def __init__(self, model_dir: str, max_len: int = None, onnx_filename: str = "model.onnx"):
+        self.model_dir = model_dir.rstrip("/")
+        tok_path = os.path.join(self.model_dir, "tokenizer.json")
+        onnx_path = os.path.join(self.model_dir, "onnx", onnx_filename)
+
+        if not os.path.exists(tok_path):
+            raise RuntimeError(f"Tokenizer not found: {tok_path}")
+        if not os.path.exists(onnx_path):
+            raise RuntimeError(f"ONNX model not found: {onnx_path}")
+
+        self.tokenizer = Tokenizer.from_file(tok_path)
+        self.max_len = max_len or int(os.getenv("EMBED_MAX_LEN", "2048"))
+
+        # CPU by default; switch to onnxruntime-gpu + CUDA providers if desired
+        providers = ["CPUExecutionProvider"]
+        self.session = ort.InferenceSession(onnx_path, providers=providers)
+
+        # Model I/O signatures
+        self.input_names = [i.name for i in self.session.get_inputs()]
+        outs = [o.name for o in self.session.get_outputs()]
+        if not outs:
+            raise RuntimeError("Could not resolve ONNX output name.")
+        self.output_name = outs[0]  # often 'last_hidden_state'
+
+    def _prepare_arrays(self, texts: List[str]):
+        max_len = self.max_len
+        input_ids, attention_mask = [], []
+        for t in texts:
+            enc = self.tokenizer.encode(t or "")
+            ids = enc.ids[:max_len]
+            att = [1] * len(ids)
+            if len(ids) < max_len:
+                pad = max_len - len(ids)
+                ids += [0] * pad
+                att += [0] * pad
+            input_ids.append(ids)
+            attention_mask.append(att)
+
+        # Optional inputs: many BERT-style models require these
+        token_type_ids = [[0] * max_len for _ in texts]          # all zeros
+        position_ids   = [list(range(max_len)) for _ in texts]   # sometimes expected
+
+        arrays = {
+            "input_ids":      np.asarray(input_ids, dtype=np.int64),
+            "attention_mask": np.asarray(attention_mask, dtype=np.int64),
+            "token_type_ids": np.asarray(token_type_ids, dtype=np.int64),
+            "position_ids":   np.asarray(position_ids, dtype=np.int64),
+        }
+        return arrays
+
+    def _masked_mean_pool(self, token_embs: np.ndarray, attn: np.ndarray) -> np.ndarray:
+        attn = attn[:, :token_embs.shape[1]].astype(np.float32)
+        attn_exp = np.expand_dims(attn, axis=-1)                 # [B, T, 1]
+        summed = (token_embs * attn_exp).sum(axis=1)             # [B, H]
+        counts = np.clip(attn_exp.sum(axis=1), 1e-6, None)       # [B, 1]
+        return summed / counts
+
+    def encode(self, texts, normalize_embeddings: bool = True):
+        if not isinstance(texts, list):
+            texts = [texts]
+
+        arrays = self._prepare_arrays(texts)
+
+        # Feed ONLY what the model actually requires
+        feed = {name: arrays[name] for name in self.input_names if name in arrays}
+        missing = [name for name in self.input_names if name not in feed]
+        if missing:
+            raise RuntimeError(f"Missing inputs not covered by adapter: {missing}")
+
+        out = self.session.run([self.output_name], feed)[0]
+        vecs = np.asarray(out, dtype=np.float32)
+
+        # Pool if the model returned token embeddings
+        if vecs.ndim == 3:                     # [B, T, H]
+            vecs = self._masked_mean_pool(vecs, arrays["attention_mask"])
+        elif vecs.ndim == 4:
+            vecs = vecs.squeeze()
+            if vecs.ndim == 3:
+                vecs = self._masked_mean_pool(vecs, arrays["attention_mask"])
+        elif vecs.ndim == 1:                   # [H] -> [1, H]
+            vecs = vecs[None, :]
+
+        # L2 normalize
+        if normalize_embeddings:
+            norms = np.linalg.norm(vecs, axis=1, keepdims=True) + 1e-12
+            vecs = vecs / norms
+
+        return vecs.tolist()

--- a/main.py
+++ b/main.py
@@ -1,18 +1,16 @@
 import sys
 import pysqlite3
 
-# Ensure Chroma uses pysqlite3 (bundled SQLite) in environments where system sqlite is old
+# Ensure Chroma uses pysqlite3 in environments where system sqlite is old
 sys.modules["sqlite3"] = pysqlite3
 sys.modules["sqlite3.dbapi2"] = pysqlite3.dbapi2
- 
+
 import os
 import re
-import io
 import uuid
 import time
 import queue
-import json
-import hashlib
+import io
 import mimetypes
 import threading
 import subprocess
@@ -20,189 +18,42 @@ import zipfile
 import base64
 import tempfile
 from pathlib import Path as _Path
-from typing import List, Optional, Dict, Any, Tuple
+from typing import Any, Dict, Optional, List
 
 import requests
 from fastapi import FastAPI, UploadFile, File, Query, Body, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse, StreamingResponse, JSONResponse
-from pydantic import BaseModel
-
-# ---------------- Vector DB ----------------
-import chromadb
-
-# ---------------- File watching ----------------
 from watchdog.observers import Observer
 from watchdog.events import FileSystemEventHandler
-
-# ---------------- Document parsing ----------------
-from pypdf import PdfReader
-from docx import Document
-from langchain_text_splitters import RecursiveCharacterTextSplitter
-from pdf2image import convert_from_path
-import pytesseract
-from bs4 import BeautifulSoup
-from PIL import Image
-import openpyxl
-import extract_msg
-
 import traceback
 
-# ---------------- Embeddings: nomic-embed-text via ONNXRuntime ----------------
-import onnxruntime as ort
-from tokenizers import Tokenizer
-import numpy as np
-
-class NomicOnnxEmbedder:
-    """
-    ONNXRuntime wrapper for nomic-ai/nomic-embed-text local model.
-
-    Expected files under EMBED_MODEL_DIR:
-      - tokenizer.json
-      - onnx/model.onnx   (change onnx_filename if you want a different variant)
-    """
-    def __init__(self, model_dir: str, max_len: int = None, onnx_filename: str = "model.onnx"):
-        import os
-        self.model_dir = model_dir.rstrip("/")
-        tok_path = os.path.join(self.model_dir, "tokenizer.json")
-        onnx_path = os.path.join(self.model_dir, "onnx", onnx_filename)
-
-        if not os.path.exists(tok_path):
-            raise RuntimeError(f"Tokenizer not found: {tok_path}")
-        if not os.path.exists(onnx_path):
-            raise RuntimeError(f"ONNX model not found: {onnx_path}")
-
-        self.tokenizer = Tokenizer.from_file(tok_path)
-        self.max_len = max_len or int(os.getenv("EMBED_MAX_LEN", "2048"))
-
-        # CPU by default; switch to onnxruntime-gpu + CUDA providers if desired
-        providers = ["CPUExecutionProvider"]
-        self.session = ort.InferenceSession(onnx_path, providers=providers)
-
-        # Model I/O signatures
-        self.input_names = [i.name for i in self.session.get_inputs()]
-        outs = [o.name for o in self.session.get_outputs()]
-        if not outs:
-            raise RuntimeError("Could not resolve ONNX output name.")
-        self.output_name = outs[0]  # often 'last_hidden_state'
-
-    def _prepare_arrays(self, texts):
-        max_len = self.max_len
-        input_ids, attention_mask = [], []
-        for t in texts:
-            enc = self.tokenizer.encode(t or "")
-            ids = enc.ids[:max_len]
-            att = [1] * len(ids)
-            if len(ids) < max_len:
-                pad = max_len - len(ids)
-                ids += [0] * pad
-                att += [0] * pad
-            input_ids.append(ids)
-            attention_mask.append(att)
-
-        # Optional inputs: many BERT-style models require these
-        token_type_ids = [[0] * max_len for _ in texts]          # all zeros
-        position_ids   = [list(range(max_len)) for _ in texts]   # sometimes expected
-
-        arrays = {
-            "input_ids":      np.asarray(input_ids, dtype=np.int64),
-            "attention_mask": np.asarray(attention_mask, dtype=np.int64),
-            "token_type_ids": np.asarray(token_type_ids, dtype=np.int64),
-            "position_ids":   np.asarray(position_ids, dtype=np.int64),
-        }
-        return arrays
-
-    def _masked_mean_pool(self, token_embs: np.ndarray, attn: np.ndarray) -> np.ndarray:
-        """
-        token_embs: [B, T, H], attn: [B, T]
-        returns: [B, H]
-        """
-        attn = attn[:, :token_embs.shape[1]].astype(np.float32)
-        attn_exp = np.expand_dims(attn, axis=-1)                 # [B, T, 1]
-        summed = (token_embs * attn_exp).sum(axis=1)             # [B, H]
-        counts = np.clip(attn_exp.sum(axis=1), 1e-6, None)       # [B, 1]
-        return summed / counts
-
-    def encode(self, texts, normalize_embeddings: bool = True):
-        if not isinstance(texts, list):
-            texts = [texts]
-
-        arrays = self._prepare_arrays(texts)
-
-        # Feed ONLY what the model actually requires
-        feed = {name: arrays[name] for name in self.input_names if name in arrays}
-        missing = [name for name in self.input_names if name not in feed]
-        if missing:
-            raise RuntimeError(f"Missing inputs not covered by adapter: {missing}")
-
-        out = self.session.run([self.output_name], feed)[0]
-        vecs = np.asarray(out, dtype=np.float32)
-
-        # Pool if the model returned token embeddings
-        if vecs.ndim == 3:                     # [B, T, H]
-            vecs = self._masked_mean_pool(vecs, arrays["attention_mask"])
-        elif vecs.ndim == 4:
-            vecs = vecs.squeeze()
-            if vecs.ndim == 3:
-                vecs = self._masked_mean_pool(vecs, arrays["attention_mask"])
-        elif vecs.ndim == 1:                   # [H] -> [1, H]
-            vecs = vecs[None, :]
-
-        # L2 normalize
-        if normalize_embeddings:
-            norms = np.linalg.norm(vecs, axis=1, keepdims=True) + 1e-12
-            vecs = vecs / norms
-
-        return vecs.tolist()
+import config
+from config import (
+    OLLAMA_URL,
+    OLLAMA_KEEP_ALIVE,
+    WATCH_DIR,
+    UPLOAD_DIR,
+    COLLECTION,
+    Q_MAX,
+    collection,
+    SUPPORTED,
+)
+from models import QueryBody, ZipRequest, IngestDocument
+from db import upsert_document, upsert_text, search, search_filtered
+from qa import ask_with_context
+from doc_utils import read_text
 
 
-
-# ---------------- Configuration ----------------
-OLLAMA_URL = os.getenv("OLLAMA_URL", "http://127.0.0.1:11434")
-OLLAMA_KEEP_ALIVE = os.getenv("OLLAMA_KEEP_ALIVE", "45m")
-EMBED_MODEL_DIR = os.getenv("EMBED_MODEL_DIR", "/opt/adam/models/nomic-ai/nomic-embed-text")
-CHAT_MODEL = os.getenv("CHAT_MODEL", "llama3:8b")  # default to fast 8B
-CHROMA_DIR = os.getenv("CHROMA_DIR", "/srv/rag/chroma")
-WATCH_DIR = os.getenv("WATCH_DIR", "/srv/rag/watched")
-UPLOAD_DIR = os.getenv("UPLOAD_DIR", "/srv/rag/uploads")
-COLLECTION = os.getenv("COLLECTION", "company_docs")
-CHUNK_SIZE = int(os.getenv("CHUNK_SIZE", "1000"))
-CHUNK_OVERLAP = int(os.getenv("CHUNK_OVERLAP", "150"))
-Q_MAX = int(os.getenv("INGEST_QUEUE_MAX", "8"))
-
-# ---------------- Model aliasing ----------------
-ALIAS_MAP = {
-    # Keep any local aliases you still use; avoid mapping removed 70B family
-    "Adam Lite": "adam-lite:latest",
-    "adam-lite": "adam-lite:latest",
-    "llama3:8b": "llama3:8b",
-}
-DEFAULT_MODEL = CHAT_MODEL
-
-
-def resolve_model(name: Optional[str]) -> str:
-    """Return an Ollama model tag given a friendly name or raw tag."""
-    if not name:
-        return DEFAULT_MODEL
-    return ALIAS_MAP.get(name, name)
-
-
-# Initialize embedder early so startup fails fast if model missing
-EMBEDDER = NomicOnnxEmbedder(EMBED_MODEL_DIR)
-
-# ---------------- FastAPI app ----------------
 app = FastAPI(title="Local RAG Service")
+
 
 @app.exception_handler(Exception)
 async def all_exception_handler(request, exc):
     tb = "".join(traceback.format_exception(type(exc), exc, exc.__traceback__))
-    # Log the full traceback to stdout/journalctl
     print("\n--- Unhandled exception ---\n", tb, flush=True)
-    # Return structured JSON so clients don't see plain text "Internal Server Error"
-    return JSONResponse(
-        status_code=500,
-        content={"error": "internal_server_error", "detail": str(exc)},
-    )
+    return JSONResponse(status_code=500, content={"error": "internal_server_error", "detail": str(exc)})
+
 
 app.add_middleware(
     CORSMiddleware,
@@ -211,350 +62,10 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
-client = chromadb.PersistentClient(path=CHROMA_DIR)
-collection = client.get_or_create_collection(COLLECTION)
 
-# ---------------- Helpers ----------------
-SUPPORTED = (
-    ".pdf", ".docx", ".txt",
-    ".md", ".csv", ".log", ".json", ".py", ".cs", ".java",
-    ".html", ".htm",
-    ".eml", ".msg",
-    ".xlsx", ".pptx",
-    ".png", ".jpg", ".jpeg", ".tiff", ".tif",
-    ".doc", ".rtf",
-)
-
-
-def sha1(path: _Path) -> str:
-    h = hashlib.sha1()
-    with path.open("rb") as f:
-        for chunk in iter(lambda: f.read(8192), b""):
-            h.update(chunk)
-    return h.hexdigest()
-
-
-def read_text(path: _Path) -> str:
-    ext = path.suffix.lower()
-
-    if ext == ".pdf":
-        # pypdf
-        try:
-            reader = PdfReader(str(path))
-            text = "\n".join(p.extract_text() or "" for p in reader.pages)
-            if text and len(text.strip()) > 50:
-                return text
-        except Exception:
-            pass
-        # pdftotext
-        try:
-            out = subprocess.run(["pdftotext", "-layout", str(path), "-"],
-                                 capture_output=True, text=True, timeout=60)
-            if out.stdout and len(out.stdout.strip()) > 50:
-                return out.stdout
-        except Exception:
-            pass
-        # OCR
-        try:
-            images = convert_from_path(str(path))
-            ocr_text = []
-            for img in images:
-                ocr_text.append(pytesseract.image_to_string(img))
-            joined = "\n".join(ocr_text)
-            if joined.strip():
-                return joined
-        except Exception:
-            pass
-        return ""
-
-    elif ext == ".docx":
-        try:
-            doc = Document(str(path))
-            return "\n".join(p.text for p in doc.paragraphs)
-        except Exception:
-            return ""
-
-    elif ext in (".txt", ".md", ".csv", ".log", ".json", ".py", ".cs", ".java"):
-        try:
-            return path.read_text(encoding="utf-8", errors="ignore")
-        except Exception:
-            return ""
-
-    elif ext in (".html", ".htm"):
-        try:
-            html = path.read_text(encoding="utf-8", errors="ignore")
-            soup = BeautifulSoup(html, "lxml")
-            return soup.get_text(separator="\n")
-        except Exception:
-            return ""
-
-    elif ext == ".eml":
-        try:
-            import email
-            msg = email.message_from_bytes(path.read_bytes())
-            parts = []
-            for part in msg.walk():
-                if part.get_content_type() == "text/plain":
-                    parts.append(part.get_payload(decode=True).decode(errors="ignore"))
-            return "\n".join(parts)
-        except Exception:
-            return ""
-
-    elif ext == ".msg":
-        try:
-            m = extract_msg.Message(str(path))
-            text = [m.subject or "", m.body or ""]
-            return "\n".join([t for t in text if t])
-        except Exception:
-            return ""
-
-    elif ext == ".xlsx":
-        try:
-            wb = openpyxl.load_workbook(str(path), data_only=True)
-            parts = []
-            for ws in wb.worksheets:
-                for row in ws.iter_rows(values_only=True):
-                    parts.append(" ".join([str(c) for c in row if c is not None]))
-            return "\n".join(parts)
-        except Exception:
-            return ""
-
-    elif ext == ".pptx":
-        try:
-            from pptx import Presentation
-            prs = Presentation(str(path))
-            parts = []
-            for slide in prs.slides:
-                for shp in slide.shapes:
-                    if hasattr(shp, "text") and shp.text:
-                        parts.append(shp.text)
-            return "\n".join(parts)
-        except Exception:
-            return ""
-
-    elif ext in (".png", ".jpg", ".jpeg", ".tiff", ".tif"):
-        try:
-            img = Image.open(str(path))
-            return pytesseract.image_to_string(img)
-        except Exception:
-            return ""
-
-    elif ext == ".doc":
-        # try antiword
-        try:
-            out = subprocess.run(["antiword", str(path)], capture_output=True, text=True, timeout=60)
-            if out.stdout.strip():
-                return out.stdout
-        except Exception:
-            pass
-        # fallback: convert to pdf via libreoffice headless
-        try:
-            subprocess.run(["libreoffice", "--headless", "--convert-to", "pdf",
-                            "--outdir", str(path.parent), str(path)], check=True, timeout=120)
-            pdf_path = path.with_suffix(".pdf")
-            if pdf_path.exists():
-                return read_text(pdf_path)
-        except Exception:
-            pass
-        return ""
-
-    elif ext == ".rtf":
-        try:
-            out = subprocess.run(["unrtf", "--text", str(path)], capture_output=True, text=True, timeout=60)
-            return out.stdout
-        except Exception:
-            return ""
-
-    else:
-        try:
-            return path.read_text(encoding="utf-8", errors="ignore")
-        except Exception:
-            return ""
-
-
-def chunk_text(text: str, size: int = CHUNK_SIZE, overlap: int = CHUNK_OVERLAP) -> List[str]:
-    text = text.strip()
-    if not text:
-        return []
-    splitter = RecursiveCharacterTextSplitter(
-        chunk_size=size,
-        chunk_overlap=overlap,
-        separators=["\n\n", "\n", ". ", " ", ""],
-    )
-    return splitter.split_text(text)
-
-
-def embed(texts: List[str]) -> List[List[float]]:
-    return EMBEDDER.encode(texts, normalize_embeddings=True)
-
-
-def upsert_document(path: _Path, source: str) -> int:
-    text = read_text(path)
-    if not text:
-        return 0
-    try:
-        collection.delete(where={"path": str(path)})
-    except Exception:
-        pass
-
-    chunks = chunk_text(text)
-    if not chunks:
-        return 0
-    embs = embed(chunks)
-
-    doc_sha = sha1(path)
-    ids = [f"{doc_sha}:{i}" for i in range(len(chunks))]
-    metas = [{"source": source, "path": str(path), "chunk": i} for i in range(len(chunks))]
-    collection.upsert(ids=ids, documents=chunks, metadatas=metas, embeddings=embs)
-    return len(chunks)
-
-
-def _sanitize_metadata(meta: Dict[str, Any]) -> Dict[str, Any]:
-    import json
-    safe: Dict[str, Any] = {}
-    for k, v in (meta or {}).items():
-        if isinstance(v, (str, int, float, bool)) or v is None:
-            safe[k] = v
-        elif isinstance(v, (list, dict, tuple, set)):
-            try:
-                safe[k] = json.dumps(v, ensure_ascii=False)
-            except Exception:
-                safe[k] = str(v)
-        else:
-            safe[k] = str(v)
-    return safe
-
-
-
-# -------- New: upsert pre-parsed TEXT (SharePoint path) --------
-def upsert_text(doc_id: str, text: str, base_meta: Dict[str, Any]) -> int:
-    """Upsert pre-parsed TEXT (string) as chunks+embeddings, storing ONLY embeddings+metadata."""
-    text = (text or "").strip()
-    if not text:
-        return 0
-    try:
-        collection.delete(where={"doc_id": doc_id})
-    except Exception:
-        pass
-    chunks = chunk_text(text)
-    if not chunks:
-        return 0
-    embs = embed(chunks)
-    ids = [f"{doc_id}:{i}" for i in range(len(chunks))]
-    metas = []
-    for i in range(len(chunks)):
-        m = _sanitize_metadata(dict(base_meta))
-        m["doc_id"] = doc_id
-        m["chunk"] = i
-        metas.append(m)
-    collection.upsert(ids=ids, documents=chunks, metadatas=metas, embeddings=embs)
-    return len(chunks)
-
-
-def search(query: str, k: int = 4) -> List[Dict[str, Any]]:
-    qemb = embed([query])[0]
-    res = collection.query(query_embeddings=[qemb], n_results=k,
-                           include=["documents", "metadatas", "distances"])
-    docs = (res.get("documents") or [[]])[0]
-    metas = (res.get("metadatas") or [[]])[0]
-    dists = (res.get("distances") or [[]])[0]
-    return [{"text": d, "meta": m, "score": float(1.0 / (1e-5 + dist))}
-            for d, m, dist in zip(docs, metas, dists)]
-
-
-def _dehedge(text: str) -> str:
-    patterns = [
-        r'(?i)^\s*(according to|based on|from)\s+(the\s+)?(provided|given)\s+(context|information|documents)\s*[:,\-]*\s*',
-        r'(?i)^\s*(according to|based on)\s+(the\s+)?document(s)?\s*[:,\-]*\s*',
-    ]
-    for p in patterns:
-        text = re.sub(p, "", text, count=1)
-    return text.strip()
-
-def ask_with_context(question: str, hits: List[dict], chat_history: Optional[List[dict]] = None, model: Optional[str] = None) -> str:
-    ql = (question or "").lower()
-
-    meta_triggers = [
-        "your name", "what is your name", "what's your name",
-        "who are you", "who is adam", "what does adam stand for",
-        "what are you", "introduce yourself"
-    ]
-    if any(t in ql for t in meta_triggers):
-        return "I am Adam - the Amentum Document and Assistance Model (ADAM)."
-
-    context = "\n\n".join([f"[{i+1}] {h['text']}" for i, h in enumerate(hits)])
-
-    sys_prompt = (
-        "You are Adam — the Amentum Document and Assistance Model (ADAM). "
-        "Answer directly and succinctly. Do not start with phrases like "
-        "'According to the provided context'. Use ONLY the provided context for factual claims and insert "
-        "inline bracket citations like [1], [2] right after the sentence they support. "
-        "Do not append a 'Sources:' section. If the answer is not in the context, say you do not know."
-    )
-
-    messages = [{"role": "system", "content": sys_prompt}]
-    if chat_history:
-        messages.extend(chat_history)
-    prompt = f"Context:\n{context}\n\nQuestion: {question}\nAnswer:"
-    messages.append({"role": "user", "content": prompt})
-
-    model_tag = resolve_model(model)
-
-    try:
-        r = requests.post(
-            f"{OLLAMA_URL}/api/chat",
-            json={
-                "model": model_tag,
-                "messages": messages,
-                "stream": False,
-                "options": {"temperature": 0.2, "num_predict": 300},
-                "keep_alive": OLLAMA_KEEP_ALIVE  # keep the 8B resident
-            },
-            timeout=120
-        )
-    except Exception as e:
-        raise HTTPException(status_code=502, detail=f"Ollama connection error: {e}")
-
-    if r.status_code != 200:
-        body = r.text
-        if len(body) > 800:
-            body = body[:800] + "...(truncated)"
-        raise HTTPException(status_code=502, detail=f"Ollama status {r.status_code}: {body}")
-
-    try:
-        j = r.json()
-    except Exception:
-        body = r.text
-        if len(body) > 800:
-            body = body[:800] + "...(truncated)"
-        raise HTTPException(status_code=502, detail=f"Ollama returned non-JSON: {body}")
-
-    msg = j.get("message") or {}
-    content = msg.get("content") or j.get("content") or ""
-
-    if not content.strip() and hits:
-        top = (hits[0].get("text") or "").strip()
-        if top and len(top) <= 200 and any(p in ql for p in ["what does", "say", "content", "quote", "exact text"]):
-            return f'It says: "{{ " ".join(top.split()) }}" [1].'
-
-    return _dehedge(content)
-
-# ---- API models & endpoints ----
-class QueryBody(BaseModel):
-    query: str
-    k: int = 4
-    history: Optional[List[dict]] = None
-    model: Optional[str] = None  # "Adam Large", "Adam Lite", or raw Ollama tag
-    # New optional filters (non-breaking)
-    org: Optional[str] = None
-    category: Optional[str] = None
-    doc_code: Optional[str] = None
-    owner: Optional[str] = None
-
-
+# ---------------- API Endpoints ----------------
 @app.post("/query")
 def query_api(body: QueryBody):
-    # Use filtered search if filters provided; else regular search
     if body.org or body.category or body.doc_code or body.owner:
         hits = search_filtered(body.query, k=body.k,
                                source=None, org=body.org, category=body.category,
@@ -563,13 +74,11 @@ def query_api(body: QueryBody):
         hits = search(body.query, k=body.k)
     answer = ask_with_context(body.query, hits, chat_history=body.history, model=body.model)
     used = sorted({int(n) for n in re.findall(r"\[(\d+)\]", answer) if n.isdigit()})
-    filtered = [hits[i-1] for i in used if 1 <= i <= len(hits)] if used else []
-    # Return richer source objects (non-breaking for existing clients)
     rich = []
     for i, h in enumerate(hits):
         meta = h.get("meta", {}) or {}
         rich.append({
-            "index": i+1,
+            "index": i + 1,
             "title": meta.get("title"),
             "org": meta.get("org"),
             "category": meta.get("category"),
@@ -577,9 +86,9 @@ def query_api(body: QueryBody):
             "revision_date": meta.get("revision_date"),
             "doc_code": meta.get("doc_code"),
             "sp_web_url": meta.get("sp_web_url"),
-            "path": meta.get("path"),   # present for legacy local docs
+            "path": meta.get("path"),
             "score": h.get("score"),
-            "snippet": (h.get("text") or "")[:400]
+            "snippet": (h.get("text") or "")[:400],
         })
     return {"answer": answer, "sources": rich}
 
@@ -643,50 +152,39 @@ def list_docs(limit: int = 10000):
 @app.post("/reset")
 def reset_api():
     try:
-        client.delete_collection(COLLECTION)
-    except Exception:
-        pass
-    global collection
-    collection = client.get_or_create_collection(COLLECTION)
-    return {"ok": True}
+        collection.delete()
+        return {"ok": True}
+    except Exception as e:
+        return {"ok": False, "error": str(e)}
+
 
 @app.get("/ollama_health")
 def ollama_health():
     try:
-        r = requests.get(f"{OLLAMA_URL}/api/tags", timeout=10)
-        ct = r.headers.get("content-type", "")
-        body = r.json() if "application/json" in ct else r.text
-        return {"ok": r.status_code == 200, "status": r.status_code, "body": body}
+        r = requests.get(f"{OLLAMA_URL}/api/tags", timeout=5)
+        return {"ok": r.status_code == 200}
     except Exception as e:
-        raise HTTPException(status_code=502, detail=f"Ollama unreachable: {e}")
+        return {"ok": False, "error": str(e)}
+
 
 @app.get("/embed_health")
 def embed_health():
     try:
-        vec = EMBEDDER.encode(["hello world"])[0]
-        return {"ok": True, "dim": len(vec), "preview": vec[:8]}
+        _ = ask_with_context("ping", [])
+        return {"ok": True}
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Embed error: {e}")
+        return {"ok": False, "error": str(e)}
 
 
-@app.get("/list_docs")
+@app.get("/documents")
 def list_documents():
     try:
-        collection = collection = client.get_or_create_collection(COLLECTION)
-
-        # Fetch all document entries with metadata
         results = collection.get(include=["metadatas", "documents"], limit=10000)
-
         docs = []
         for i in range(len(results["ids"])):
-            doc_info = {
-                "doc_id": results["ids"][i],
-                "metadata": results["metadatas"][i],
-            }
+            doc_info = {"doc_id": results["ids"][i], "metadata": results["metadatas"][i]}
             docs.append(doc_info)
-
         return JSONResponse(content={"documents": docs, "count": len(docs)})
-
     except Exception as e:
         return JSONResponse(status_code=500, content={"error": str(e)})
 
@@ -715,7 +213,7 @@ if _Path(WATCH_DIR).exists():
 
 # ---------------- Ingest queue & jobs ----------------
 INGEST_Q: "queue.Queue[tuple[str,str,str]]" = queue.Queue(maxsize=Q_MAX)
-JOBS: dict[str, dict] = {}
+JOBS: Dict[str, Dict[str, Any]] = {}
 
 
 def _ingest_worker():
@@ -731,7 +229,11 @@ def _ingest_worker():
             INGEST_Q.task_done()
 
 
-threading.Thread(target=_ingest_worker, daemon=True).start()
+def _start_worker():
+    threading.Thread(target=_ingest_worker, daemon=True).start()
+
+
+_start_worker()
 
 
 @app.post("/upload_async")
@@ -770,7 +272,6 @@ def _is_under_allowed(p: _Path) -> bool:
                 if rp.is_relative_to(r.resolve()):
                     return True
             except AttributeError:
-                # Python 3.9 doesn't have Path.is_relative_to
                 if str(rp).startswith(str(r.resolve()) + os.sep):
                     return True
         return False
@@ -787,18 +288,10 @@ def download(path: str, inline: bool = False):
         raise HTTPException(403, "forbidden path")
 
     mt, _ = mimetypes.guess_type(str(p))
-    resp = FileResponse(
-        path=str(p),
-        media_type=mt or "application/octet-stream",
-        filename=p.name,
-    )
+    resp = FileResponse(path=str(p), media_type=mt or "application/octet-stream", filename=p.name)
     if inline:
         resp.headers["Content-Disposition"] = f'inline; filename="{p.name}"'
     return resp
-
-
-class ZipRequest(BaseModel):
-    paths: List[str]
 
 
 @app.post("/download_zip")
@@ -815,71 +308,6 @@ def download_zip(req: ZipRequest):
     return StreamingResponse(buf, media_type="application/zip", headers=headers)
 
 
-# ---------------- Filtered search ----------------
-def search_filtered(
-    query: str,
-    k: int = 4,
-    path: Optional[str] = None,
-    paths: Optional[List[str]] = None,
-    prefix: Optional[str] = None,
-    source: Optional[str] = None,
-    org: Optional[str] = None,
-    category: Optional[str] = None,
-    doc_code: Optional[str] = None,
-    owner: Optional[str] = None,
-) -> List[Dict[str, Any]]:
-    qemb = embed([query])[0]
-    include = ["documents", "metadatas", "distances"]
-
-    def to_hits(res):
-        docs = (res.get("documents") or [[]])[0]
-        metas = (res.get("metadatas") or [[]])[0]
-        dists = (res.get("distances") or [[]])[0]
-        return [{"text": d, "meta": m, "score": float(1.0 / (1e-5 + dist))}
-                for d, m, dist in zip(docs, metas, dists)]
-
-    results: List[Dict[str, Any]] = []
-
-    if path:
-        res = collection.query(query_embeddings=[qemb], n_results=max(k, 8),
-                               include=include, where={"path": path})
-        results.extend(to_hits(res))
-    elif paths:
-        for p in paths:
-            res = collection.query(query_embeddings=[qemb], n_results=max(2, k // max(1, len(paths))) + 6,
-                                   include=include, where={"path": p})
-            results.extend(to_hits(res))
-    elif prefix:
-        try:
-            res = collection.query(query_embeddings=[qemb], n_results=max(k, 12),
-                                   include=include, where={"path": {"$contains": prefix}})
-            results.extend(to_hits(res))
-        except Exception:
-            res = collection.query(query_embeddings=[qemb], n_results=max(k * 5, 20), include=include)
-            results.extend([h for h in to_hits(res) if str(h["meta"].get("path", "")).startswith(prefix)])
-    elif source or org or category or doc_code or owner:
-        where: Dict[str, Any] = {}
-        if source:   where["source"] = source
-        if org:      where["org"] = org
-        if category: where["category"] = category
-        if doc_code: where["doc_code"] = doc_code
-        if owner:    where["owner"] = owner
-        res = collection.query(query_embeddings=[qemb], n_results=max(k, 12),
-                               include=include, where=where)
-        results.extend(to_hits(res))
-    else:
-        res = collection.query(query_embeddings=[qemb], n_results=k, include=include)
-        results.extend(to_hits(res))
-
-    seen: Dict[Tuple[Any, Any], Dict[str, Any]] = {}
-    for h in results:
-        key = (h["meta"].get("doc_id") or h["meta"].get("path"), h["meta"].get("chunk"))
-        if key not in seen or h["score"] > seen[key]["score"]:
-            seen[key] = h
-    hits = sorted(seen.values(), key=lambda x: x["score"], reverse=True)[:k]
-    return hits
-
-
 @app.post("/query_path")
 def query_path(body: Dict[str, Any] = Body(...)):
     query = body.get("query", "")
@@ -890,7 +318,6 @@ def query_path(body: Dict[str, Any] = Body(...)):
     prefix = body.get("prefix")
     source = body.get("source")
     model = body.get("model")
-
     org = body.get("org")
     category = body.get("category")
     doc_code = body.get("doc_code")
@@ -899,75 +326,24 @@ def query_path(body: Dict[str, Any] = Body(...)):
     hits = search_filtered(query, k=k, path=path, paths=paths, prefix=prefix, source=source,
                            org=org, category=category, doc_code=doc_code, owner=owner)
     answer = ask_with_context(query, hits, chat_history=history, model=model)
-
     used = sorted({int(n) for n in re.findall(r"\[(\d+)\]", answer) if n.isdigit()})
     filtered = [hits[i-1] for i in used if 1 <= i <= len(hits)] if used else []
     return {"answer": answer, "sources": filtered}
 
 
-# ---------------- New: Pydantic model for SharePoint ingest ----------------
-class IngestDocument(BaseModel):
-    # Identity & links (from SharePoint)
-    sp_site_id: Optional[str] = None
-    sp_list_id: Optional[str] = None
-    sp_item_id: Optional[str] = None
-    sp_drive_id: Optional[str] = None
-    sp_file_id: Optional[str] = None
-    sp_web_url: str
-
-    # Versioning
-    etag: Optional[str] = None
-    version_label: Optional[str] = None
-
-    # Core metadata
-    title: Optional[str] = None
-    doc_code: Optional[str] = None
-    org_code: Optional[str] = None
-    org: Optional[str] = None
-    category: Optional[str] = None
-    owner: Optional[str] = None
-    version: Optional[str] = None
-    revision_date: Optional[str] = None
-    latest_review_date: Optional[str] = None
-    document_review_date: Optional[str] = None
-    review_approval_date: Optional[str] = None
-    keywords: Optional[List[str]] = None
-    enterprise_keywords: Optional[List[str]] = None
-    association_ids: Optional[List[str]] = None
-    domain: Optional[str] = "HR"
-    allowed_groups: Optional[List[str]] = None
-
-    # Content options (you’ll use content_bytes)
-    file_name: Optional[str] = None
-    content_bytes: Optional[str] = None   # base64 of the file bytes
-    text_content: Optional[str] = None    # if you pre-extract text in your SP worker
-
-    # Optional overrides
-    chunk_size: Optional[int] = None
-    chunk_overlap: Optional[int] = None
-    persist: Optional[bool] = False       # ignored; never persist files locally
-
-
-# ---------------- New: SharePoint-first ingest (no local persistence) ----------------
 @app.post("/ingest_document")
 def ingest_document_api(body: IngestDocument):
-    """
-    Accept SharePoint metadata + content (base64 bytes or pre-extracted text),
-    parse to text in-memory (if needed), chunk, embed, upsert. No file persistence.
-    """
-    # Use per-request chunk overrides if provided
-    global CHUNK_SIZE, CHUNK_OVERLAP
-    orig_size, orig_overlap = CHUNK_SIZE, CHUNK_OVERLAP
+    orig_size, orig_overlap = config.CHUNK_SIZE, config.CHUNK_OVERLAP
     try:
-        if body.chunk_size: CHUNK_SIZE = int(body.chunk_size)
-        if body.chunk_overlap: CHUNK_OVERLAP = int(body.chunk_overlap)
+        if body.chunk_size:
+            config.CHUNK_SIZE = int(body.chunk_size)
+        if body.chunk_overlap:
+            config.CHUNK_OVERLAP = int(body.chunk_overlap)
 
-        # Build stable versioned doc_id
         version_key = body.version_label or body.etag or "v1"
         spid = str(body.sp_item_id or body.sp_file_id or body.sp_web_url)
         doc_id = f"{spid}:{version_key}"
 
-        # Base metadata attached to every chunk
         base_meta = {
             "source": "sharepoint",
             "sp_site_id": body.sp_site_id,
@@ -978,7 +354,6 @@ def ingest_document_api(body: IngestDocument):
             "sp_web_url": body.sp_web_url,
             "etag": body.etag,
             "version_label": body.version_label,
-
             "title": body.title,
             "doc_code": body.doc_code,
             "org_code": body.org_code,
@@ -997,12 +372,10 @@ def ingest_document_api(body: IngestDocument):
             "allowed_groups": body.allowed_groups or ["AllEmployees"],
         }
 
-        # 1) If text provided, use directly (fastest)
         if body.text_content and str(body.text_content).strip():
             n = upsert_text(doc_id, body.text_content, base_meta)
             return {"ok": True, "doc_id": doc_id, "chunks": n, "used": "text_content"}
 
-        # 2) Else parse from base64 content bytes ephemerally
         if body.content_bytes:
             raw = base64.b64decode(body.content_bytes)
             suffix = _Path(body.file_name).suffix if body.file_name else ""
@@ -1022,19 +395,14 @@ def ingest_document_api(body: IngestDocument):
 
         raise HTTPException(status_code=400, detail="Provide either text_content or content_bytes.")
     finally:
-        CHUNK_SIZE, CHUNK_OVERLAP = orig_size, orig_overlap
+        config.CHUNK_SIZE, config.CHUNK_OVERLAP = orig_size, orig_overlap
 
 
-# ---------------- New: Delete by SharePoint identity ----------------
 @app.delete("/delete_sp")
 def delete_by_sp(sp_item_id: Optional[str] = Query(None),
                  sp_file_id: Optional[str] = Query(None),
                  version: Optional[str] = Query(None),
                  etag: Optional[str] = Query(None)):
-    """
-    Delete all chunks for a SharePoint document identity. If version/etag is
-    supplied, only that version is removed; otherwise all versions are removed.
-    """
     where: Dict[str, Any] = {}
     if sp_item_id:
         where["sp_item_id"] = sp_item_id

--- a/models.py
+++ b/models.py
@@ -1,0 +1,54 @@
+from typing import Any, Dict, List, Optional
+from pydantic import BaseModel
+
+
+class QueryBody(BaseModel):
+    query: str
+    k: int = 4
+    history: Optional[List[dict]] = None
+    model: Optional[str] = None
+    org: Optional[str] = None
+    category: Optional[str] = None
+    doc_code: Optional[str] = None
+    owner: Optional[str] = None
+
+
+class ZipRequest(BaseModel):
+    paths: List[str] = []
+
+
+class IngestDocument(BaseModel):
+    sp_site_id: Optional[str] = None
+    sp_list_id: Optional[str] = None
+    sp_item_id: Optional[str] = None
+    sp_drive_id: Optional[str] = None
+    sp_file_id: Optional[str] = None
+    sp_web_url: str
+
+    etag: Optional[str] = None
+    version_label: Optional[str] = None
+
+    title: Optional[str] = None
+    doc_code: Optional[str] = None
+    org_code: Optional[str] = None
+    org: Optional[str] = None
+    category: Optional[str] = None
+    owner: Optional[str] = None
+    version: Optional[str] = None
+    revision_date: Optional[str] = None
+    latest_review_date: Optional[str] = None
+    document_review_date: Optional[str] = None
+    review_approval_date: Optional[str] = None
+    keywords: Optional[List[str]] = None
+    enterprise_keywords: Optional[List[str]] = None
+    association_ids: Optional[List[str]] = None
+    domain: Optional[str] = "HR"
+    allowed_groups: Optional[List[str]] = None
+
+    file_name: Optional[str] = None
+    content_bytes: Optional[str] = None
+    text_content: Optional[str] = None
+
+    chunk_size: Optional[int] = None
+    chunk_overlap: Optional[int] = None
+    persist: Optional[bool] = False

--- a/qa.py
+++ b/qa.py
@@ -1,0 +1,86 @@
+import re
+from typing import List, Optional
+
+import requests
+from fastapi import HTTPException
+
+from config import OLLAMA_KEEP_ALIVE, OLLAMA_URL, resolve_model
+
+
+def dehedge(text: str) -> str:
+    patterns = [
+        r'(?i)^\s*(according to|based on|from)\s+(the\s+)?(provided|given)\s+(context|information|documents)\s*[:,\-]*\s*',
+        r'(?i)^\s*(according to|based on)\s+(the\s+)?document(s)?\s*[:,\-]*\s*',
+    ]
+    for p in patterns:
+        text = re.sub(p, "", text, count=1)
+    return text.strip()
+
+
+def ask_with_context(question: str, hits: List[dict], chat_history: Optional[List[dict]] = None, model: Optional[str] = None) -> str:
+    ql = (question or "").lower()
+
+    meta_triggers = [
+        "your name", "what is your name", "what's your name",
+        "who are you", "who is adam", "what does adam stand for",
+        "what are you", "introduce yourself"
+    ]
+    if any(t in ql for t in meta_triggers):
+        return "I am Adam - the Amentum Document and Assistance Model (ADAM)."
+
+    context = "\n\n".join([f"[{i+1}] {h['text']}" for i, h in enumerate(hits)])
+
+    sys_prompt = (
+        "You are Adam — the Amentum Document and Assistance Model (ADAM). "
+        "Answer directly and succinctly. Do not start with phrases like "
+        "'According to the provided context'. Use ONLY the provided context for factual claims and insert "
+        "inline bracket citations like [1], [2] right after the sentence they support. "
+        "Do not append a 'Sources:' section. If the answer is not in the context, say you do not know."
+    )
+
+    messages = [{"role": "system", "content": sys_prompt}]
+    if chat_history:
+        messages.extend(chat_history)
+    prompt = f"Context:\n{context}\n\nQuestion: {question}\nAnswer:"
+    messages.append({"role": "user", "content": prompt})
+
+    model_tag = resolve_model(model)
+
+    try:
+        r = requests.post(
+            f"{OLLAMA_URL}/api/chat",
+            json={
+                "model": model_tag,
+                "messages": messages,
+                "stream": False,
+                "options": {"temperature": 0.2, "num_predict": 300},
+                "keep_alive": OLLAMA_KEEP_ALIVE
+            },
+            timeout=120
+        )
+    except Exception as e:
+        raise HTTPException(status_code=502, detail=f"Ollama connection error: {e}")
+
+    if r.status_code != 200:
+        body = r.text
+        if len(body) > 800:
+            body = body[:800] + "...(truncated)"
+        raise HTTPException(status_code=502, detail=f"Ollama status {r.status_code}: {body}")
+
+    try:
+        j = r.json()
+    except Exception:
+        body = r.text
+        if len(body) > 800:
+            body = body[:800] + "...(truncated)"
+        raise HTTPException(status_code=502, detail=f"Ollama returned non-JSON: {body}")
+
+    msg = j.get("message") or {}
+    content = msg.get("content") or j.get("content") or ""
+
+    if not content.strip() and hits:
+        top = (hits[0].get("text") or "").strip()
+        if top and len(top) <= 200 and any(p in ql for p in ["what does", "say", "content", "quote", "exact text"]):
+            return f'It says: "{{ " ".join(top.split()) }}" [1].'
+
+    return dehedge(content)


### PR DESCRIPTION
## Summary
- extract embedding logic into `embedding.py`
- centralize settings and vector collection setup in `config.py`
- move document parsing, database ops, and QA helpers into their own modules
- trim `main.py` to a FastAPI entry point using the new modules

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68a5dbc2cb6c8324a7d8814bbaafece7