### PR TITLE
enhance ingest endpoint with text cleanup and metadata

### DIFF
--- a/main.py
+++ b/main.py
@@ -490,12 +490,7 @@ def _sanitize_metadata(meta: Dict[str, Any]) -> Dict[str, Any]:
     for k, v in (meta or {}).items():
         if isinstance(v, (str, int, float, bool)) or v is None:
             safe[k] = v
-        elif isinstance(v, list):
-            if all(isinstance(i, (str, int, float, bool)) or i is None for i in v):
-                safe[k] = v
-            else:
-                safe[k] = json.dumps(v, ensure_ascii=False)
-        elif isinstance(v, dict):
+        elif isinstance(v, (list, dict, tuple, set)):
             try:
                 safe[k] = json.dumps(v, ensure_ascii=False)
             except Exception:


### PR DESCRIPTION
## Summary
- clean document text before chunking to remove headers, signatures, and boilerplate
- summarize documents and extract category and keywords via local LLM
- store summary, category, and keywords for each chunk; reject docs under 500 chars

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_68a92b07b89c8324a686c41fc9c0e4e1