### PR TITLE
feat: prioritize docs_v2 collection and add reranker bypass

### DIFF
--- a/adampy/pipeline/semantic_rag.py
+++ b/adampy/pipeline/semantic_rag.py
@@ -23,6 +23,7 @@ class Passage:
     score_dense: Optional[float] = None
     rrf_score: Optional[float] = None
     rerank_score: Optional[float] = None
+    collection: str = ""
 
     def to_dict(self) -> Dict[str, Any]:
         return asdict(self)
@@ -62,7 +63,9 @@ def generate_query_variants(
     return {"rewritten": rewritten, "alternates": alternates, "hyde": hyde}
 
 
-def dense_retrieve(chroma_collection, query: str, k: int) -> List[Passage]:
+def dense_retrieve(
+    chroma_collection, query: str, k: int, collection_name: str
+) -> List[Passage]:
     res = chroma_collection.query(
         query_texts=[query],
         n_results=k,
@@ -85,6 +88,7 @@ def dense_retrieve(chroma_collection, query: str, k: int) -> List[Passage]:
                 section_heading=meta.get("section_heading") or meta.get("heading", ""),
                 page_num=meta.get("page") or meta.get("page_num"),
                 score_dense=1 - float(dist) if dist is not None else None,
+                collection=collection_name,
             )
         )
     return passages
@@ -150,6 +154,7 @@ def build_grounded_answer(
                 "url": p.url,
                 "span_start": 0,
                 "span_end": len(p.text),
+                "collection": p.collection,
             }
         )
     context = "\n\n".join(context_lines)

--- a/config.py
+++ b/config.py
@@ -14,11 +14,15 @@ if BaseSettings:
         SEMRAG_RRF_CUTOFF: int = 100
         SEMRAG_RERANK_KEEP: int = 15
         SEMRAG_USE_HYDE: bool = False
+        COLLECTION_PRIMARY: str = "docs_v2"
+        COLLECTION_FALLBACK: str = "docs_v1"
+        USE_COLLECTION_FALLBACK: bool = True
         OLLAMA_HOST: str = "http://127.0.0.1:11434"
         RERANKER_MODEL_PATH: str = "/opt/rag-models/bge-reranker-v2-m3"
         RERANKER_BATCH_SIZE: int = 16
         RERANKER_MAX_LEN: int = 512
         STRICT_CITATION_CHECKS: bool = True
+        DISPLAY_TOP_K_DEFAULT: int = 5
 
         class Config:
             env_prefix = ""
@@ -35,14 +39,18 @@ else:
     class Settings:
         SEMRAG_ENABLED: bool = _get_bool("SEMRAG_ENABLED", True)
         SEMRAG_VARIANTS: int = _get_int("SEMRAG_VARIANTS", 2)
-        SEMRAG_K_PER_VARIANT: int = _get_int("SEMRAG_K_PER_VARIANT", 10)
-        SEMRAG_RRF_CUTOFF: int = _get_int("SEMRAG_RRF_CUTOFF", 50)
-        SEMRAG_RERANK_KEEP: int = _get_int("SEMRAG_RERANK_KEEP", 10)
+        SEMRAG_K_PER_VARIANT: int = _get_int("SEMRAG_K_PER_VARIANT", 20)
+        SEMRAG_RRF_CUTOFF: int = _get_int("SEMRAG_RRF_CUTOFF", 100)
+        SEMRAG_RERANK_KEEP: int = _get_int("SEMRAG_RERANK_KEEP", 15)
         SEMRAG_USE_HYDE: bool = _get_bool("SEMRAG_USE_HYDE", False)
+        COLLECTION_PRIMARY: str = os.getenv("COLLECTION_PRIMARY", "docs_v2")
+        COLLECTION_FALLBACK: str = os.getenv("COLLECTION_FALLBACK", "docs_v1")
+        USE_COLLECTION_FALLBACK: bool = _get_bool("USE_COLLECTION_FALLBACK", True)
         OLLAMA_HOST: str = os.getenv("OLLAMA_HOST", "http://127.0.0.1:11434")
         RERANKER_MODEL_PATH: str = os.getenv("RERANKER_MODEL_PATH", "/opt/rag-models/bge-reranker-v2-m3")
         RERANKER_BATCH_SIZE: int = _get_int("RERANKER_BATCH_SIZE", 16)
         RERANKER_MAX_LEN: int = _get_int("RERANKER_MAX_LEN", 512)
         STRICT_CITATION_CHECKS: bool = _get_bool("STRICT_CITATION_CHECKS", True)
+        DISPLAY_TOP_K_DEFAULT: int = _get_int("DISPLAY_TOP_K_DEFAULT", 5)
 
     settings = Settings()

--- a/main.py
+++ b/main.py
@@ -1238,7 +1238,9 @@ def rewrite_prompt(prompt: str) -> str:
 # ---- API models & endpoints ----
 class QueryBody(BaseModel):
     query: str
-    k: int = 4
+    k: int = settings.DISPLAY_TOP_K_DEFAULT
+    display_k: Optional[int] = None
+    bypass_reranker: bool = False
     history: Optional[List[dict]] = None
     model: Optional[str] = None  # "Adam Large", "Adam Lite", or raw Ollama tag
     # New optional filters (non-breaking)
@@ -1262,12 +1264,19 @@ class QueryResponse(BaseModel):
     fusion: List[Dict[str, Any]] = []
     rerank: List[Dict[str, Any]] = []
     final_context: List[Dict[str, Any]] = []
+    display_context: List[Dict[str, Any]] = []
+    display_k: int = settings.DISPLAY_TOP_K_DEFAULT
+    used_collections: List[str] = []
+    bypass_reranker: bool = False
     phantom_citations_found: bool = False
     phantom_citation_details: List[Any] = []
 
 
 def semantic_query(body: QueryBody) -> QueryResponse:
     ollama = OllamaClient()
+    display_k = (
+        body.display_k if body.display_k is not None else body.k or settings.DISPLAY_TOP_K_DEFAULT
+    )
     variants = (
         generate_query_variants(
             ollama,
@@ -1286,14 +1295,21 @@ def semantic_query(body: QueryBody) -> QueryResponse:
     if settings.SEMRAG_USE_HYDE and variants.get("hyde"):
         query_set.append(variants["hyde"])
 
-    retrieved_runs = []
-    per_query_results = []
+    retrieved_runs: List[Dict[str, Any]] = []
+    per_query_results: List[List[Any]] = []
+
+    primary = client.get_or_create_collection(
+        settings.COLLECTION_PRIMARY, embedding_function=CHROMA_EMBED
+    )
     for q in query_set:
-        hits = dense_retrieve(retriever, q, settings.SEMRAG_K_PER_VARIANT)
+        hits = dense_retrieve(
+            primary, q, settings.SEMRAG_K_PER_VARIANT, settings.COLLECTION_PRIMARY
+        )
         retrieved_runs.append(
             {
                 "query": q,
                 "k": settings.SEMRAG_K_PER_VARIANT,
+                "collection": settings.COLLECTION_PRIMARY,
                 "results": [
                     {
                         "doc_id": p.doc_id,
@@ -1312,36 +1328,89 @@ def semantic_query(body: QueryBody) -> QueryResponse:
         per_query_results.append(hits)
 
     fused = rrf_fuse(per_query_results, settings.SEMRAG_RRF_CUTOFF)
+    used_collections = [settings.COLLECTION_PRIMARY]
+    fallback_used = False
+    fallback_threshold = 10
+    if (
+        settings.USE_COLLECTION_FALLBACK
+        and len(fused) < fallback_threshold
+    ):
+        fallback = client.get_or_create_collection(
+            settings.COLLECTION_FALLBACK, embedding_function=CHROMA_EMBED
+        )
+        for q in query_set:
+            hits_fb = dense_retrieve(
+                fallback, q, settings.SEMRAG_K_PER_VARIANT, settings.COLLECTION_FALLBACK
+            )
+            retrieved_runs.append(
+                {
+                    "query": q,
+                    "k": settings.SEMRAG_K_PER_VARIANT,
+                    "collection": settings.COLLECTION_FALLBACK,
+                    "results": [
+                        {
+                            "doc_id": p.doc_id,
+                            "chunk_id": p.chunk_id,
+                            "score_dense": p.score_dense,
+                            "rank": i + 1,
+                            "title": p.title,
+                            "url": p.url,
+                            "section_heading": p.section_heading,
+                            "page_num": p.page_num,
+                        }
+                        for i, p in enumerate(hits_fb)
+                    ],
+                }
+            )
+            per_query_results.append(hits_fb)
+        fused = rrf_fuse(per_query_results, settings.SEMRAG_RRF_CUTOFF)
+        used_collections.append(settings.COLLECTION_FALLBACK)
+        fallback_used = True
+        print("[semantic_query] Fallback collection used", flush=True)
     fusion_logs = [
         {
             "doc_id": p.doc_id,
             "chunk_id": p.chunk_id,
             "rrf_score": p.rrf_score,
             "fused_rank": i + 1,
+            "collection": p.collection,
         }
         for i, p in enumerate(fused)
     ]
 
-    reranker = load_reranker_or_reuse()
-    reranked = rerank(reranker, body.query, fused, settings.SEMRAG_RERANK_KEEP)
-    rerank_logs = [
-        {
-            "doc_id": p.doc_id,
-            "chunk_id": p.chunk_id,
-            "rerank_score": p.rerank_score,
-            "rerank_rank": i + 1,
-        }
-        for i, p in enumerate(reranked)
-    ]
+    if body.bypass_reranker:
+        reranked = fused[: settings.SEMRAG_RERANK_KEEP]
+        rerank_logs: List[Dict[str, Any]] = []
+        print("[semantic_query] Bypassing reranker", flush=True)
+    else:
+        reranker = load_reranker_or_reuse()
+        reranked = rerank(reranker, body.query, fused, settings.SEMRAG_RERANK_KEEP)
+        rerank_logs = [
+            {
+                "doc_id": p.doc_id,
+                "chunk_id": p.chunk_id,
+                "rerank_score": p.rerank_score,
+                "rerank_rank": i + 1,
+                "collection": p.collection,
+            }
+            for i, p in enumerate(reranked)
+        ]
+
+    if fallback_used and any(
+        p.collection == settings.COLLECTION_FALLBACK for p in reranked
+    ):
+        print("[semantic_query] Fallback passages contributed to final results", flush=True)
 
     answer_raw, final_context = build_grounded_answer(ollama, body.query, reranked)
     final_text, phantom_found, phantom_details = validate_and_fix_citations(
         answer_raw, reranked
     )
 
+    display_context = final_context[:display_k]
+
     return QueryResponse(
         answer=final_text,
-        sources=final_context,
+        sources=display_context,
         original_query=body.query,
         rewritten_query=variants.get("rewritten") or body.query,
         prompt_rewritten=bool(variants.get("rewritten")) and body.rewrite,
@@ -1351,6 +1420,10 @@ def semantic_query(body: QueryBody) -> QueryResponse:
         fusion=fusion_logs,
         rerank=rerank_logs,
         final_context=final_context,
+        display_context=display_context,
+        display_k=display_k,
+        used_collections=used_collections,
+        bypass_reranker=body.bypass_reranker,
         phantom_citations_found=phantom_found,
         phantom_citation_details=phantom_details,
     )

--- a/tests/test_semantic_rag.py
+++ b/tests/test_semantic_rag.py
@@ -77,6 +77,10 @@ def test_query_response_fields():
         "fusion",
         "rerank",
         "final_context",
+        "display_context",
+        "display_k",
+        "used_collections",
+        "bypass_reranker",
         "phantom_citations_found",
     ]:
         assert key in block


### PR DESCRIPTION
## Summary
- search docs_v2 collection first with optional fallback to docs_v1
- support debug `bypass_reranker` flag and separate `display_k` handling
- include collection info and display-context in `/query` responses

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af1598318c832488e2ca8676ff9858